### PR TITLE
cd-ls

### DIFF
--- a/src/main/java/ru/hse/spb/sd/sharkova/interpreter/CLIParser.kt
+++ b/src/main/java/ru/hse/spb/sd/sharkova/interpreter/CLIParser.kt
@@ -7,7 +7,7 @@ import java.util.regex.Pattern
 
 
 class CLIParser : Parser {
-    private val keywords = listOf("cat", "echo", "wc", "pwd", "exit", "grep")
+    private val keywords = listOf("cat", "echo", "wc", "pwd", "exit", "grep", "cd", "ls")
     private val identifierRegex = Regex("[_a-z][_a-z0-9]*")
     private val substitutionRegex = Regex("^\\$$identifierRegex")
     private val identifierAssignmentPattern = Pattern.compile("^$identifierRegex=")
@@ -238,6 +238,8 @@ class CLIParser : Parser {
                 "pwd" -> { interpreter.executePwd() }
                 "exit" -> { interpreter.executeExit() }
                 "grep" -> { processGrep(arguments, previousResult) }
+                "cd" -> { interpreter.executeCd(arguments) }
+                "ls" -> { interpreter.executeLs(arguments) }
                 else -> {emptyList()}
             }
         } catch (e: InterpreterException) {

--- a/src/main/java/ru/hse/spb/sd/sharkova/interpreter/CLIParser.kt
+++ b/src/main/java/ru/hse/spb/sd/sharkova/interpreter/CLIParser.kt
@@ -242,12 +242,17 @@ class CLIParser : Parser {
                 "ls" -> { interpreter.executeLs(arguments) }
                 else -> {emptyList()}
             }
-        } catch (e: InterpreterException) {
-            val errorMessage = e.message
-            if (errorMessage != null) {
-                errorList.add(errorMessage)
+        } catch (e: Exception) {
+            when (e) {
+                is InterpreterException, is EnvironmentException -> {
+                    val errorMessage = e.message
+                    if (errorMessage != null) {
+                        errorList.add(errorMessage)
+                    }
+                    emptyList()
+                }
+                else -> throw e
             }
-            emptyList()
         }
     }
 

--- a/src/main/java/ru/hse/spb/sd/sharkova/interpreter/Environment.kt
+++ b/src/main/java/ru/hse/spb/sd/sharkova/interpreter/Environment.kt
@@ -5,11 +5,22 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 
+/**
+ * Environment represents system state and provides methods to interact with it.
+ */
 object Environment {
     private var currentDirectory = Paths.get(".").toAbsolutePath().normalize()
 
+    /**
+     * Getter for a working directory.
+     * @return current directory
+     */
     fun getCurrentDirectory(): Path = currentDirectory
 
+    /**
+     * Sets a new working directory, if exists.
+     * @param directory path to a new directory
+     */
     fun setCurrentDirectory(directory: String) {
         val newDirectory = currentDirectory.resolve(directory)
 
@@ -20,5 +31,10 @@ object Environment {
         currentDirectory = newDirectory.toAbsolutePath().normalize()
     }
 
+    /**
+     * Getter for a file in or outside working directory.
+     * @param path path to the file
+     * @return required file
+     */
     fun getFile(path: String): File = currentDirectory.resolve(path).toFile()
 }

--- a/src/main/java/ru/hse/spb/sd/sharkova/interpreter/Environment.kt
+++ b/src/main/java/ru/hse/spb/sd/sharkova/interpreter/Environment.kt
@@ -1,0 +1,24 @@
+package ru.hse.spb.sd.sharkova.interpreter
+
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+object Environment {
+    private var currentDirectory = Paths.get(".").toAbsolutePath().normalize()
+
+    fun getCurrentDirectory(): Path = currentDirectory
+
+    fun setCurrentDirectory(directory: String) {
+        val newDirectory = currentDirectory.resolve(directory)
+
+        if (!Files.exists(newDirectory) || !Files.isDirectory(newDirectory)) {
+            throw WrongDirectoryException()
+        }
+
+        currentDirectory = newDirectory.toAbsolutePath().normalize()
+    }
+
+    fun getFile(path: String): File = currentDirectory.resolve(path).toFile()
+}

--- a/src/main/java/ru/hse/spb/sd/sharkova/interpreter/exceptions.kt
+++ b/src/main/java/ru/hse/spb/sd/sharkova/interpreter/exceptions.kt
@@ -10,3 +10,7 @@ abstract class InterpreterException(message: String) : Exception(message)
 
 class IncorrectArgumentException(commandName: String, argumentName: String, message: String) :
         InterpreterException("$commandName: $argumentName: $message")
+
+abstract class EnvironmentException(message: String) : Exception(message)
+
+class WrongDirectoryException(message: String = "can not change to a new directory") : EnvironmentException(message)

--- a/src/test/java/ru/hse/spb/sd/sharkova/interpreter/InterpreterTest.kt
+++ b/src/test/java/ru/hse/spb/sd/sharkova/interpreter/InterpreterTest.kt
@@ -2,6 +2,7 @@ package ru.hse.spb.sd.sharkova.interpreter
 
 import org.junit.Assert.*
 import org.junit.Test
+import java.io.File
 import java.io.IOException
 
 class InterpreterTest {
@@ -72,6 +73,40 @@ class InterpreterTest {
         val res = parser.parseInput("pwd")
         val expected = "pwd".runCommand()
         assertEquals(listOf(expected), res)
+    }
+
+    @Test
+    fun testCdNoArguments() {
+        val expectedOutput = emptyList<String>()
+        val expectedPath = System.getProperty("user.dir")
+        val res = parser.parseInput("cd")
+        assertEquals(expectedOutput, res)
+        assertEquals(expectedPath, System.getProperty("user.dir"))
+    }
+
+    @Test
+    fun testCdSubdirectory() {
+        val expectedOutput = emptyList<String>()
+        val expectedPath = System.getProperty("user.dir") + File.separator + "src"
+        val res = parser.parseInput("cd src")
+        assertEquals(expectedOutput, res)
+        assertEquals(expectedPath, System.getProperty("user.dir"))
+    }
+
+    @Test
+    fun testLsNoArguments() {
+        val root = System.getProperty("user.dir")
+        System.setProperty("user.dir", root + File.separator + "src")
+        val expectedOutput = listOf("main", "test")
+        val res = parser.parseInput("ls")
+        assertEquals(expectedOutput, res)
+    }
+
+    @Test
+    fun testLsSubdirectory() {
+        val expectedOutput = listOf("main", "test")
+        val res = parser.parseInput("ls src")
+        assertEquals(expectedOutput, res)
     }
 
     // run this one separately because it literally exits

--- a/src/test/java/ru/hse/spb/sd/sharkova/interpreter/InterpreterTest.kt
+++ b/src/test/java/ru/hse/spb/sd/sharkova/interpreter/InterpreterTest.kt
@@ -1,9 +1,11 @@
 package ru.hse.spb.sd.sharkova.interpreter
 
 import org.junit.Assert.*
+import org.junit.Before
 import org.junit.Test
 import java.io.File
 import java.io.IOException
+import java.nio.file.Paths
 
 class InterpreterTest {
     private val file1Lines = listOf("text\n", "line\n", "\n", "the previous line was an empty one\n")
@@ -19,6 +21,11 @@ class InterpreterTest {
     private val file2Wc = "0 109 651"
     
     private val parser = CLIParser()
+
+    @Before
+    fun initDirectory() {
+        Environment.setCurrentDirectory(Paths.get(".").toAbsolutePath().normalize().toString())
+    }
 
     @Test
     fun testEcho() {
@@ -78,25 +85,24 @@ class InterpreterTest {
     @Test
     fun testCdNoArguments() {
         val expectedOutput = emptyList<String>()
-        val expectedPath = System.getProperty("user.dir")
+        val expectedPath = System.getProperty("user.home")
         val res = parser.parseInput("cd")
         assertEquals(expectedOutput, res)
-        assertEquals(expectedPath, System.getProperty("user.dir"))
+        assertEquals(expectedPath, Environment.getCurrentDirectory().toString())
     }
 
     @Test
     fun testCdSubdirectory() {
         val expectedOutput = emptyList<String>()
-        val expectedPath = System.getProperty("user.dir") + File.separator + "src"
+        val expectedPath = Environment.getCurrentDirectory().toString() + File.separator + "src"
         val res = parser.parseInput("cd src")
         assertEquals(expectedOutput, res)
-        assertEquals(expectedPath, System.getProperty("user.dir"))
+        assertEquals(expectedPath, Environment.getCurrentDirectory().toString())
     }
 
     @Test
     fun testLsNoArguments() {
-        val root = System.getProperty("user.dir")
-        System.setProperty("user.dir", root + File.separator + "src")
+        Environment.setCurrentDirectory("src")
         val expectedOutput = listOf("main", "test")
         val res = parser.parseInput("ls")
         assertEquals(expectedOutput, res)


### PR DESCRIPTION
Добавлять новые команды было удобно, не надо было думать над выводом результата и принятием аргументов из строки или пайпа.
Показалось странным, что парсер выполняет запуск команд. Почему-то для парсера есть и интерфейс, и его реализация, а для интерпретатора только один класс. Думаю, что реализации команд можно было бы вынести в отдельные файлы, чтобы не загромождать интерпретатор.